### PR TITLE
cookie-consent onetrust

### DIFF
--- a/blocks/marketo/marketo.js
+++ b/blocks/marketo/marketo.js
@@ -1,19 +1,5 @@
-import { createTag } from '../../scripts/scripts.js';
+import { createTag, loadScript } from '../../scripts/scripts.js';
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
-
-const loadScript = (url, attrs) => {
-  const head = document.querySelector('head');
-  const script = document.createElement('script');
-  script.src = url;
-  if (attrs) {
-    // eslint-disable-next-line no-restricted-syntax, guard-for-in
-    for (const attr in attrs) {
-      script.setAttribute(attr, attrs[attr]);
-    }
-  }
-  head.append(script);
-  return script;
-};
 
 const embedMarketoForm = (formId, divId) => {
   // PDF Viewer for doc pages

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,7 +1,33 @@
 // eslint-disable-next-line import/no-cycle
-import { sampleRUM } from './lib-franklin.js';
+import { loadScript } from './scripts.js';
+import { sampleRUM, fetchPlaceholders } from './lib-franklin.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-// add more delayed functionality here
+// fetch placeholders file
+const placeholders = await fetchPlaceholders();
+
+// OneTrust Cookies Consent Notice start
+const otId = placeholders.onetrustid;
+if (otId) {
+  loadScript('https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', {
+    type: 'text/javascript',
+    charset: 'UTF-8',
+    'data-domain-script': `${otId}`,
+  });
+
+  window.OptanonWrapper = () => {};
+}
+
+const allButtons = document.querySelectorAll('a.button');
+allButtons.forEach((button) => {
+  if (button.getAttribute('href').includes('cookie-policy')) {
+    button.addEventListener('click', (e) => {
+    // eslint-disable-next-line no-undef
+      OneTrust.ToggleInfoDisplay();
+      e.preventDefault();
+    });
+  }
+});
+// OneTrust Cookies Consent Notice end

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -89,6 +89,25 @@ function buildPageDivider(main) {
 }
 
 /**
+ * Loads the script in the head section
+ * @param {string} url and other attrs
+ * @returns script
+ */
+export function loadScript(url, attrs) {
+  const head = document.querySelector('head');
+  const script = document.createElement('script');
+  script.src = url;
+  if (attrs) {
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+    for (const attr in attrs) {
+      script.setAttribute(attr, attrs[attr]);
+    }
+  }
+  head.append(script);
+  return script;
+}
+
+/**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */


### PR DESCRIPTION
- added helper function to load scripts to head section of the page
- delayed cookie-consent onetrust loading via placeholders
- for /pages/zemax-cookie-policy, added an click event listener to attach the cookie options

Fix #25 
Test URLs:
- Before: https://main--zemax--hlxsites.hlx.page/
- After: https://issue-25-cookieconsent--zemax--hlxsites.hlx.page/
