### PR TITLE
wrap image with links

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -276,6 +276,27 @@ export function decorateExternalLinks(main) {
   });
 }
 
+export function linkPicture(picture) {
+  const nextSib = picture.parentNode.nextElementSibling;
+  if (nextSib) {
+    const a = nextSib.querySelector('a');
+    if (a && a.textContent.startsWith('https://')) {
+      a.innerHTML = '';
+      a.className = '';
+      a.appendChild(picture);
+    }
+  }
+}
+
+export function decorateLinkedPictures(main) {
+  /* thanks to word online */
+  main.querySelectorAll('picture').forEach((picture) => {
+    if (!picture.closest('div.block')) {
+      linkPicture(picture);
+    }
+  });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -283,6 +304,7 @@ export function decorateExternalLinks(main) {
 // eslint-disable-next-line import/prefer-default-export
 export function decorateMain(main) {
   // hopefully forward compatible button decoration
+  decorateLinkedPictures(main);
   decorateButtons(main);
   decorateExternalLinks(main);
   decorateIcons(main);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #111

Test URLs:
- Before: https://main--zemax--hlxsites.hlx.page/blogs/news/20-year-optics-veteran-talks-product-development-cycles-productivity-hacks-and-the-future
- After: https://issue-image-wraplink--zemax--hlxsites.hlx.page/blogs/news/20-year-optics-veteran-talks-product-development-cycles-productivity-hacks-and-the-future

See this image (and in the document) as a link is following this image which eventually gets wrapped up with the image.
![Screenshot 2023-05-11 at 4 44 46 PM](https://github.com/hlxsites/zemax/assets/10811320/f083da78-8dcc-4359-a663-28029f6188c3)

