### PR TITLE
Fix #165: Do not wait for fetch. 

### DIFF
--- a/blocks/user-info/user-info.js
+++ b/blocks/user-info/user-info.js
@@ -12,7 +12,7 @@ export default async function decorate(block) {
   if (userId == null || userId === undefined || accessToken == null || accessToken === undefined) {
     window.location.assign(`${window.location.origin}`);
   } else {
-    await fetch(`${DYNAMIC_365_DOMAIN}insided_get_user_link?auth0_id=${userId}`, {
+    fetch(`${DYNAMIC_365_DOMAIN}insided_get_user_link?auth0_id=${userId}`, {
       method: 'GET',
       headers: {
         'Content-type': 'application/json; charset=UTF-8',

--- a/blocks/user-licenses/user-licenses.js
+++ b/blocks/user-licenses/user-licenses.js
@@ -226,10 +226,10 @@ export default async function decorate(block) {
   const accessToken = localStorage.getItem('accessToken');
   const DYNAMIC_365_DOMAIN = getEnvironmentConfig('dev').profile.dynamic365domain;
 
-  if (userId == null || userId === undefined || accessToken == null || accessToken === undefined) {
+  if (!userId || !accessToken) {
     window.location.assign(`${window.location.origin}`);
   } else {
-    await fetch(`${DYNAMIC_365_DOMAIN}dynamics_get_licenses_by_auth0id?auth0_id=${userId}`, {
+    fetch(`${DYNAMIC_365_DOMAIN}dynamics_get_licenses_by_auth0id?auth0_id=${userId}`, {
       method: 'GET',
       headers: {
         'Content-type': 'application/json; charset=UTF-8',

--- a/blocks/user-licenses/user-licenses.js
+++ b/blocks/user-licenses/user-licenses.js
@@ -613,23 +613,16 @@ function addTabFeature() {
 }
 
 export default async function decorate(block) {
+  // noinspection ES6MissingAwait
+  loadData(block);
+}
+
+async function loadData(block) {
   const data = await execute('dynamics_get_licenses_by_auth0id', '', 'GET');
 
-  if (userId == null || userId === undefined || accessToken == null || accessToken === undefined) {
-    window.location.assign(`${window.location.origin}`);
-  } else {
-    fetch(`${DYNAMIC_365_DOMAIN}dynamics_get_licenses_by_auth0id?auth0_id=${userId}`, {
-      method: 'GET',
-      headers: {
-        'Content-type': 'application/json; charset=UTF-8',
-        Authorization: `bearer ${accessToken}`,
-      },
-    })
-      .then(async (response) => {
-        const data = await response.json();
-        const licenseTableHeadingMapping = createTableHeaderMapping(data);
-        const tabDiv = createTag('div', { class: 'tabs' });
-        const tabListUl = createTag('ul', { class: 'tabs-nav', role: 'tablist' });
+  const licenseTableHeadingMapping = createTableHeaderMapping(data);
+  const tabDiv = createTag('div', { class: 'tabs' });
+  const tabListUl = createTag('ul', { class: 'tabs-nav', role: 'tablist' });
 
   // Render tab headings
   licenseTableHeadingMapping.forEach((heading, index) => {

--- a/blocks/user-tickets/user-tickets.js
+++ b/blocks/user-tickets/user-tickets.js
@@ -13,7 +13,7 @@ export default async function decorate(block) {
   if (userId == null || userId === undefined || accessToken == null || accessToken === undefined) {
     window.location.assign(`${window.location.origin}`);
   } else {
-    await fetch(`${DYNAMIC_365_DOMAIN}zendesk_tickets_by_id?auth0_id=${userId}&user_email=${userEmail}&zemax_zendeskid=${contactid}`, {
+    fetch(`${DYNAMIC_365_DOMAIN}zendesk_tickets_by_id?auth0_id=${userId}&user_email=${userEmail}&zemax_zendeskid=${contactid}`, {
       method: 'GET',
       headers: {
         'Content-type': 'application/json; charset=UTF-8',

--- a/blocks/user-webroles/user-webroles.js
+++ b/blocks/user-webroles/user-webroles.js
@@ -12,7 +12,7 @@ export default async function decorate(block) {
   if (userId == null || userId === undefined || accessToken == null || accessToken === undefined) {
     window.location.assign(`${window.location.origin}`);
   } else {
-    await fetch(`${DYNAMIC_365_DOMAIN}dynamics_get_webrole?auth0_id=${userId}`, {
+    fetch(`${DYNAMIC_365_DOMAIN}dynamics_get_webrole?auth0_id=${userId}`, {
       method: 'GET',
       headers: {
         'Content-type': 'application/json; charset=UTF-8',


### PR DESCRIPTION
Ideally the async code is moved to an async function like `loadData`, where all the async stuff happens with `await` instead of `then()`. And in `function decorate(block)`we don't `await` the call to `loadData` and show a spinner until completion. 

Fix #165

Test URLs:
- Before: https://main--zemax--hlxsites.hlx.page
- After: https://165-no-wait-for-fetch--zemax--hlxsites.hlx.page

@shehjadkhan-ansys I know you plan to optimize this in the future. This is a minimal change to already improve the overall performance. 